### PR TITLE
Fix hardcoded paths from setup script

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# EditorContig, see https://editorconfig.org for your editor support.
+
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+
+[*.sh]
+indent_style = space
+indent_size = 2

--- a/yocto/setup.sh
+++ b/yocto/setup.sh
@@ -1,7 +1,18 @@
+# assume we're in the same dir as layers
+if [ -n "$BASH_SOURCE" ]; then
+  SCRIPT=$BASH_SOURCE
+else
+  SCRIPT=$0
+fi
+LAYERS_ROOT="$(realpath -e "$(dirname "$SCRIPT")")"
+
 # qemuarm64 is a more generic target
 export MACHINE=raspberrypi4-64
 
-. poky/oe-init-build-env
+. "${LAYERS_ROOT}/poky/oe-init-build-env" "$@"
 
-grep meta-sel4 conf/bblayers.conf 2>/dev/null 1>&2 || echo 'BBLAYERS += "/workspace/vm-images/meta-sel4"' >> conf/bblayers.conf
-grep meta-raspberrypi conf/bblayers.conf 2>/dev/null 1>&2 || echo 'BBLAYERS += "/workspace/vm-images/meta-raspberrypi"' >> conf/bblayers.conf
+grep meta-sel4 conf/bblayers.conf 2>/dev/null 1>&2 || \
+  printf 'BBLAYERS += "%s/meta-sel4"\n' "$LAYERS_ROOT" >> conf/bblayers.conf
+
+grep meta-raspberrypi conf/bblayers.conf 2>/dev/null 1>&2 || \
+  printf 'BBLAYERS += "%s/meta-raspberrypi"\n' "$LAYERS_ROOT" >> conf/bblayers.conf


### PR DESCRIPTION
Having some degree of configurability is desirable e.g. when using multiple build environments.