### PR TITLE
virtio-blk to mainline

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,7 @@ USER build
 
 RUN pip3 install \
     aenum \
-    orderedset \
+    ordered_set \
     plyplus \
     pyfdt \
     pyyaml

--- a/yocto/setup.sh
+++ b/yocto/setup.sh
@@ -16,3 +16,6 @@ grep meta-sel4 conf/bblayers.conf 2>/dev/null 1>&2 || \
 
 grep meta-raspberrypi conf/bblayers.conf 2>/dev/null 1>&2 || \
   printf 'BBLAYERS += "%s/meta-raspberrypi"\n' "$LAYERS_ROOT" >> conf/bblayers.conf
+
+grep meta-oe conf/bblayers.conf 2>/dev/null 1>&2 || \
+  printf 'BBLAYERS += "%s/meta-openembedded/meta-oe"\n' "$LAYERS_ROOT" >> conf/bblayers.conf


### PR DESCRIPTION
Compared to original `wip/hlyytine-virtio-blk`, repo commands now point to `tii/development`