### PR TITLE
docker: use Debian bullseye as base

### DIFF
--- a/.github/actions/repo-manifest-checkout/Dockerfile
+++ b/.github/actions/repo-manifest-checkout/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2022, Technology Innovation Institute
-FROM ubuntu:21.04
+FROM debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/.github/actions/vm-image/Dockerfile
+++ b/.github/actions/vm-image/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2022, Technology Innovation Institute
-FROM ubuntu:21.04
+FROM debian:bullseye
 
 ARG DEBIAN_FRONTEND=noninteractive
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04
+FROM debian:bullseye
 
 # tzdata noninteractive install
 ENV TZ=Europe/Helsinki
@@ -101,7 +101,6 @@ RUN pip3 install \
 RUN \
     git clone https://github.com/seL4/capdl.git /home/build/capdl && \
     cd /home/build/capdl/capDL-tool && \
-    git reset --hard 3fc1a1525de2c23bc397830d5fcb744e2573efb3 && \
     stack build --only-dependencies && \
     cd /home/build && \
     rm -rf /home/build/capdl


### PR DESCRIPTION
Align base image with upstream.

Signed-off-by: Markku Ahvenjärvi <markkux@ssrc.tii.ae>