### PR TITLE
Revert manifest checkout action to use ubuntu

### DIFF
--- a/.github/actions/repo-manifest-checkout/Dockerfile
+++ b/.github/actions/repo-manifest-checkout/Dockerfile
@@ -1,5 +1,5 @@
 # Copyright 2022, Technology Innovation Institute
-FROM debian:bullseye
+FROM ubuntu:22.04
 
 ARG DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
repo tool is not available in Debian Bullseye.

Signed-off-by: Markku Ahvenjärvi <markkux@ssrc.tii.ae>