### PR TITLE
fix: add previously removed 'shell' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,3 +29,7 @@ docker:
 
 linux-image:
 	@scripts/build_yocto.sh
+
+shell:
+	@docker/enter_container.sh
+


### PR DESCRIPTION
shell target was accidentally removed in previous commit. Sorry!

Signed-off-by: Markku Ahvenjärvi <markkux@ssrc.tii.ae>