### PR TITLE
Add initramfs for driver-VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,18 +150,12 @@ subnet 192.168.5.0 netmask 255.255.255.0 {
     option routers 192.168.5.1;
     next-server 192.168.5.1;
 
-    option root-path "192.168.5.1:/srv/nfs/rpi4,vers=3,proto=tcp";
+    option root-path "192.168.5.1:/srv/nfs/rpi4,vers=3,proto=tcp,nolock";
 }
 </pre>
 
 It is the most convenient to use TCP since the Fedora firewall will block UDP
 by default.
-
-### Extract root filesystem to NFS share
-
-<pre>
-host% <b>sudo tar -C /srv/nfs/rpi4 -xjpvf ${WORKSPACE}/vm-images/build/tmp/deploy/images/raspberrypi4-64/vm-image-driver-raspberrypi4-64.tar.bz2</b>
-</pre>
 
 ### Setup Raspberry Pi 4 for network booting
 
@@ -185,10 +179,11 @@ host$ <b>make shell</b>
 container$ <b>cd vm-images</b>
 container$ <b>. setup.sh</b>
 container$ <b>bitbake vm-image-driver</b>
-container$ <b>bitbake vm-image-user</b>
+container$ <b>bitbake vm-image-boot</b>
 
-# copy kernel image in place, and build qemu seL4 vm_qemu_virtio
-container$ <b>cp vm-images/build/tmp/deploy/images/raspberrypi4-64/Image projects/camkes-vm-images/rpi4/linux</b>
+# copy kernel and initramfs image in place, and build qemu seL4 vm_qemu_virtio
+container$ <b>cp vm-images/build/tmp/deploy/images/vm-raspberrypi4-64/Image projects/camkes-vm-images/rpi4/linux</b>
+container$ <b>cp vm-images/build/tmp/deploy/images/vm-raspberrypi4-64/vm-image-boot-vm-raspberrypi4-64.cpio.gz projects/camkes-vm-images/rpi4/rootfs.cpio.gz</b>
 container$ <b>make rpi4_defconfig</b>
 container$ <b>make vm_qemu_virtio</b>
 # exit container
@@ -199,9 +194,6 @@ host$ <b>cp rpi4_vm_qemu_virtio/images/capdl-loader-image-arm-bcm2711 /var/lib/t
 
 # expose driver-VM image via NFS (update your directory to command)
 host$ <b>tar -C /srv/nfs/rpi4 -xjpvf vm-images/build/tmp/deploy/images/vm-raspberrypi4-64/vm-image-driver-raspberrypi4-64.tar.bz2</b>
-
-# copy user-VM image to NFS
-host$ <b>cp vm-images/build/tmp/deploy/images/vm-raspberrypi4-64/vm-image-user-vm-raspberrypi4-64.wic.qcow2 /srv/nfs/rpi4/myimg.qcow2</b>
 
 # create host/guest shared directory
 host$ <b>mkdir /srv/nfs/rpi4/host</b>

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ subnet 192.168.5.0 netmask 255.255.255.0 {
     range dynamic-bootp 192.168.5.200 192.168.5.254;
     option broadcast-address 192.168.5.255;
     option routers 192.168.5.1;
-    option next-server 192.168.5.1;
+    next-server 192.168.5.1;
 
     option root-path "192.168.5.1:/srv/nfs/rpi4,vers=3,proto=tcp";
 }

--- a/yocto/setup.sh
+++ b/yocto/setup.sh
@@ -19,3 +19,10 @@ grep meta-raspberrypi conf/bblayers.conf 2>/dev/null 1>&2 || \
 
 grep meta-oe conf/bblayers.conf 2>/dev/null 1>&2 || \
   printf 'BBLAYERS += "%s/meta-openembedded/meta-oe"\n' "$LAYERS_ROOT" >> conf/bblayers.conf
+
+grep meta-networking conf/bblayers.conf 2>/dev/null 1>&2 || \
+  printf 'BBLAYERS += "%s/meta-openembedded/meta-networking"\n' "$LAYERS_ROOT" >> conf/bblayers.conf
+
+# meta-networking needs meta-python
+grep meta-python conf/bblayers.conf 2>/dev/null 1>&2 || \
+  printf 'BBLAYERS += "%s/meta-openembedded/meta-python"\n' "$LAYERS_ROOT" >> conf/bblayers.conf


### PR DESCRIPTION
To use TUN/TAP networking with QEMU, we need to set up it before mounting NFS root for driver-VM. Hence we need a minimal initramfs with bridge-utils and tunctl.

Signed-off-by: Hannu Lyytinen <hannux@ssrc.tii.ae>