### PR TITLE
Move options to config file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ rpi4_defconfig:
 	@echo 'CROSS_COMPILE=aarch64-linux-gnu-' >> .config
 
 rpi4_trace_defconfig: rpi4_defconfig
-	@echo 'SEL4_TRACE=ON' >> .config
+	@echo 'SEL4_BUILD_OPTIONS_FILE=tii_sel4_build/hardware/rpi4/sel4-trace-build.config' >> .config
 
 build_camkes: .config
 	@scripts/build_camkes.sh

--- a/hardware/rpi4/sel4-trace-build.config
+++ b/hardware/rpi4/sel4-trace-build.config
@@ -1,0 +1,2 @@
+-DKernelArmExportPMUUser=ON
+-DKernelBenchmarks=track_kernel_entries

--- a/scripts/build_sel4.sh
+++ b/scripts/build_sel4.sh
@@ -27,11 +27,17 @@ mkdir -p "${BUILDDIR}"
 
 ln -rs tools/seL4/cmake-tool/init-build.sh "${BUILDDIR}"
 ln -rs "${SRCDIR}/easy-settings.cmake" "${BUILDDIR}"
+if [ -r "${SEL4_BUILD_OPTIONS_FILE}" ]; then
+  ln -rs "${SEL4_BUILD_OPTIONS_FILE}" "${BUILDDIR}/extra-options.config"
+fi
 
 cd "${BUILDDIR}" || exit 2
 
-if [ "x${SEL4_TRACE}" = "xON" ]; then
-  TRACE="-DKernelArmExportPMUUser=ON -DKernelBenchmarks=track_kernel_entries"
+
+EXTRA_BUILD_OPTIONS=""
+if [ -r "extra-options.config" ]; then
+  echo "SOURCE BUILD OPTIONS!"
+  EXTRA_BUILD_OPTIONS="$(tr '\n' ' ' < extra-options.config)"
 fi
 
 # shellcheck disable=SC2068
@@ -40,7 +46,7 @@ fi
   -DAARCH64=1 \
   -DPLATFORM="${PLATFORM}" \
   -DCROSS_COMPILER_PREFIX="${CROSS_COMPILE}" \
-  ${TRACE} \
+  ${EXTRA_BUILD_OPTIONS} \
   $@
 
 ninja


### PR DESCRIPTION
Proposal for decoupling the build options from the build script. The benefit here is that this wouldn't tie the build scripts to any particular HW or architecture.

This method could be applied to CROSS_COMPILE and other options too.

The configuration is done in two phases (symlink and then read the contents) so that one can view what configuration options were used for building.

What do you think?