### PR TITLE
Hotfix: fix second build in case of pr created for wip/ci/ branch

### DIFF
--- a/.github/workflows/trigger-push-ci.yml
+++ b/.github/workflows/trigger-push-ci.yml
@@ -10,8 +10,23 @@ on:
   workflow_dispatch:
 
 jobs:
+  pr-check:
+    runs-on: ubuntu-latest
+    outputs:
+      number: ${{ steps.PR.outputs.number }}
+    steps:
+      - uses: 8BitJonny/gh-get-current-pr@2.2.0
+        id: PR
+  skip-trigger:
+    runs-on: ubuntu-latest
+    needs: pr-check
+    if: ${{ needs.pr-check.outputs.number }}
+    steps:
+      - run: echo "PR number is ${{ needs.pr-check.outputs.number }} skip this trigger.."
   build-vm-images:
+    needs: pr-check
     uses: ./.github/workflows/build-vm-images.yml
+    if: ${{ ! needs.pr-check.outputs.number }}
     with:
       branch-override: ${{ github.ref_name }}
     secrets:


### PR DESCRIPTION
* Check if PR is opened and skip push-ci if so